### PR TITLE
Add cookie consent banner with Google Analytics integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,13 @@
     <link rel="apple-touch-icon" href="/logo192.png" />
     <title>GTA V Snapmatic to JPEG / JPG Converter</title>
     <meta name="description" content="GTA V Snapmatic to JPEG / JPG Converter." />
+    <script type="text/plain" data-category="analytics" async src="https://www.googletagmanager.com/gtag/js?id=G-D5F8NFKGHY"></script>
+    <script type="text/plain" data-category="analytics">
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-D5F8NFKGHY');
+    </script>
   </head>
   <body>
     <a

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-dropzone": "^14.2.2",
-        "tailwindcss": "^4.2.2"
+        "tailwindcss": "^4.2.2",
+        "vanilla-cookieconsent": "^3.1.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.5",
@@ -11714,6 +11715,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vanilla-cookieconsent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vanilla-cookieconsent/-/vanilla-cookieconsent-3.1.0.tgz",
+      "integrity": "sha512-/McNRtm/3IXzb9dhqMIcbquoU45SzbN2VB+To4jxEPqMmp7uVniP6BhGLjU8MC7ZCDsNQVOp27fhQTM/ruIXAA==",
       "license": "MIT"
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.2",
-    "tailwindcss": "^4.2.2"
+    "tailwindcss": "^4.2.2",
+    "vanilla-cookieconsent": "^3.1.0"
   },
   "overrides": {
     "serialize-javascript": "^7.0.3"

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import StyledDropzone from './StyledDropzone';
 import UpdatePrompt from './UpdatePrompt';
+import CookieConsent from './CookieConsent';
 import { convertSnapmaticToJpeg } from '../helpers/util';
 import JSZip from 'jszip';
 
@@ -72,6 +73,7 @@ const App = () => {
   return (
     <>
       <UpdatePrompt />
+      <CookieConsent />
       <div className="px-4 pb-4 text-center">
         <img
           src={`${import.meta.env.BASE_URL}logo192.png`}

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+import 'vanilla-cookieconsent/dist/cookieconsent.css';
+import * as CookieConsent from 'vanilla-cookieconsent';
+
+const CookieConsentComponent = () => {
+  useEffect(() => {
+    CookieConsent.run({
+      categories: {
+        necessary: {
+          enabled: true,
+          readOnly: true,
+        },
+        analytics: {},
+      },
+      language: {
+        default: 'en',
+        translations: {
+          en: {
+            consentModal: {
+              title: 'We use cookies',
+              description:
+                'We use analytics cookies to understand how visitors use this site. You can accept or reject them.',
+              acceptAllBtn: 'Accept all',
+              acceptNecessaryBtn: 'Reject all',
+              showPreferencesBtn: 'Manage preferences',
+            },
+            preferencesModal: {
+              title: 'Cookie preferences',
+              acceptAllBtn: 'Accept all',
+              acceptNecessaryBtn: 'Reject all',
+              savePreferencesBtn: 'Save preferences',
+              sections: [
+                {
+                  title: 'Necessary cookies',
+                  description:
+                    'These cookies are required for the site to function and cannot be disabled.',
+                  linkedCategory: 'necessary',
+                },
+                {
+                  title: 'Analytics cookies',
+                  description:
+                    'These cookies help us understand how visitors interact with the site (Google Analytics).',
+                  linkedCategory: 'analytics',
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+  }, []);
+
+  return null;
+};
+
+export default CookieConsentComponent;

--- a/src/components/__tests__/App.tsx
+++ b/src/components/__tests__/App.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-
 import App from '../App';
 import userEvent from '@testing-library/user-event';
 import * as fs from 'fs';
 import { vi } from 'vitest';
+
+vi.mock('vanilla-cookieconsent/dist/cookieconsent.css', () => ({}));
+vi.mock('vanilla-cookieconsent', () => ({ run: vi.fn() }));
 
 const selectAndGetFileInput = () => {
   const button = screen.getByText(/select files/i);

--- a/src/components/__tests__/CookieConsent.tsx
+++ b/src/components/__tests__/CookieConsent.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { vi } from 'vitest';
+import * as CookieConsent from 'vanilla-cookieconsent';
+import CookieConsentComponent from '../CookieConsent';
+
+vi.mock('vanilla-cookieconsent/dist/cookieconsent.css', () => ({}));
+vi.mock('vanilla-cookieconsent', () => ({
+  run: vi.fn(),
+}));
+
+const mockRun = vi.mocked(CookieConsent.run);
+
+describe('CookieConsent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing', () => {
+    const { container } = render(<CookieConsentComponent />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('calls CookieConsent.run on mount with correct config', () => {
+    render(<CookieConsentComponent />);
+    expect(mockRun).toHaveBeenCalledTimes(1);
+    const config = mockRun.mock.calls[0][0];
+    expect(config.categories).toHaveProperty('necessary');
+    expect(config.categories!.necessary!.readOnly).toBe(true);
+    expect(config.categories).toHaveProperty('analytics');
+    expect(config.language?.default).toBe('en');
+  });
+
+  it('does not call CookieConsent.run again on re-render', () => {
+    const { rerender } = render(<CookieConsentComponent />);
+    rerender(<CookieConsentComponent />);
+    expect(mockRun).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
GA4 scripts are blocked by default (type="text/plain") and only activated after the user consents via vanilla-cookieconsent, ensuring GDPR compliance.