### PR TITLE
Track user interactions with Google Analytics events

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,6 +3,7 @@ import StyledDropzone from './StyledDropzone';
 import UpdatePrompt from './UpdatePrompt';
 import CookieConsent from './CookieConsent';
 import { convertSnapmaticToJpeg } from '../helpers/util';
+import { trackEvent } from '../helpers/analytics';
 import JSZip from 'jszip';
 
 const buttonClass =
@@ -37,22 +38,31 @@ const App = () => {
       return;
     }
 
+    trackEvent('upload_files', { count: files.length });
     setLoading(true);
-    let error = false;
+    let failedCount = 0;
     const newImages: Image[] = [];
     for await (const inputFile of files) {
       try {
         const file = await convertSnapmaticToJpeg(inputFile);
         newImages.push({ file, src: URL.createObjectURL(file) });
       } catch (e) {
-        error = true;
+        failedCount++;
       }
     }
 
-    if (error) {
+    if (failedCount > 0) {
       alert(
         'Some images could not be converted, as they were not valid Snapmatic images',
       );
+      trackEvent('conversion_failure', { failed_count: failedCount });
+    }
+
+    if (newImages.length > 0) {
+      trackEvent('convert_images', {
+        count: newImages.length,
+        failed_count: failedCount,
+      });
     }
 
     setImages(images => images.concat(newImages));
@@ -67,6 +77,7 @@ const App = () => {
   }, [images]);
 
   const clearAll = () => {
+    trackEvent('clear_all', { count: images.length });
     setImages([]);
   };
 
@@ -110,6 +121,9 @@ const App = () => {
                   title="Download all images"
                   download="GTA V snaps.zip"
                   className={buttonClass}
+                  onClick={() =>
+                    trackEvent('download_all_zip', { count: images.length })
+                  }
                 >
                   Download all
                 </a>
@@ -125,7 +139,11 @@ const App = () => {
             <ul className="p-0 mt-4 mx-auto list-none max-w-full md:max-w-[50vw]">
               {images.map((image, index) => (
                 <li key={index} className="mt-4">
-                  <a href={image.src} download={image.file.name}>
+                  <a
+                    href={image.src}
+                    download={image.file.name}
+                    onClick={() => trackEvent('download_image')}
+                  >
                     <img
                       src={image.src}
                       alt=""

--- a/src/components/UpdatePrompt.tsx
+++ b/src/components/UpdatePrompt.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useRegisterSW } from 'virtual:pwa-register/react';
+import { trackEvent } from '../helpers/analytics';
 
 const UpdatePrompt = () => {
   const {
@@ -15,7 +16,10 @@ const UpdatePrompt = () => {
     <div className="fixed bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-3 bg-[#1c1f24] text-white text-sm px-4 py-3 rounded-xl shadow-lg z-50 whitespace-nowrap">
       <span>A new version is available.</span>
       <button
-        onClick={() => updateServiceWorker(true)}
+        onClick={() => {
+          trackEvent('pwa_update_accepted');
+          updateServiceWorker(true);
+        }}
         className="cursor-pointer bg-white text-[#1c1f24] font-semibold px-3 py-1 rounded-lg hover:bg-gray-200 transition-colors"
       >
         Update

--- a/src/components/__tests__/App.tsx
+++ b/src/components/__tests__/App.tsx
@@ -4,6 +4,7 @@ import App from '../App';
 import userEvent from '@testing-library/user-event';
 import * as fs from 'fs';
 import { vi } from 'vitest';
+import * as analytics from '../../helpers/analytics';
 
 vi.mock('vanilla-cookieconsent/dist/cookieconsent.css', () => ({}));
 vi.mock('vanilla-cookieconsent', () => ({ run: vi.fn() }));
@@ -58,8 +59,11 @@ const [validFile1, validFile2] = ['snapmatic1', 'snapmatic2'].map(
 );
 
 describe('App', () => {
+  let trackEventSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    trackEventSpy = vi.spyOn(analytics, 'trackEvent');
   });
 
   it('renders correctly', () => {
@@ -115,5 +119,89 @@ describe('App', () => {
     expect(screen.queryByText(/click any image to download it/i)).toBeNull();
     expect(screen.queryByTitle(/clear all images/i)).toBeNull();
     expect(screen.queryByTitle(/download all images/i)).toBeNull();
+  });
+
+  it('tracks upload_files event when files are selected', async () => {
+    render(<App />);
+    const fileInput = selectAndGetFileInput();
+    await uploadAndCheck(fileInput, [validFile1, validFile2]);
+    expect(trackEventSpy).toHaveBeenCalledWith('upload_files', { count: 2 });
+  });
+
+  it('tracks convert_images event after successful conversion', async () => {
+    render(<App />);
+    const fileInput = selectAndGetFileInput();
+    await uploadAndCheck(fileInput, [validFile1]);
+    await checkConvertedFiles([validFile1]);
+    expect(trackEventSpy).toHaveBeenCalledWith('convert_images', {
+      count: 1,
+      failed_count: 0,
+    });
+  });
+
+  it('tracks conversion_failure event when files fail to convert', async () => {
+    render(<App />);
+    const fileInput = selectAndGetFileInput();
+    await uploadAndCheck(fileInput, [invalidFile1]);
+    expect(trackEventSpy).toHaveBeenCalledWith('conversion_failure', {
+      failed_count: 1,
+    });
+  });
+
+  it('does not track convert_images when all files fail', async () => {
+    render(<App />);
+    const fileInput = selectAndGetFileInput();
+    await uploadAndCheck(fileInput, [invalidFile1]);
+    expect(trackEventSpy).not.toHaveBeenCalledWith(
+      'convert_images',
+      expect.anything(),
+    );
+  });
+
+  it('tracks convert_images and conversion_failure when mixed files are uploaded', async () => {
+    render(<App />);
+    const fileInput = selectAndGetFileInput();
+    await uploadAndCheck(fileInput, [invalidFile1, validFile1]);
+    await checkConvertedFiles([validFile1]);
+    expect(trackEventSpy).toHaveBeenCalledWith('conversion_failure', {
+      failed_count: 1,
+    });
+    expect(trackEventSpy).toHaveBeenCalledWith('convert_images', {
+      count: 1,
+      failed_count: 1,
+    });
+  });
+
+  it('tracks clear_all event with image count when "Clear all" is clicked', async () => {
+    render(<App />);
+    const fileInput = selectAndGetFileInput();
+    await uploadAndCheck(fileInput, [validFile1]);
+    await checkConvertedFiles([validFile1]);
+    await userEvent.click(screen.getByTitle(/clear all images/i));
+    expect(trackEventSpy).toHaveBeenCalledWith('clear_all', { count: 1 });
+  });
+
+  it('tracks download_image event when an image is clicked', async () => {
+    render(<App />);
+    const fileInput = selectAndGetFileInput();
+    await uploadAndCheck(fileInput, [validFile1]);
+    await checkConvertedFiles([validFile1]);
+    const imageAnchor = screen
+      .getByTitle(`${validFile1.name}.jpg`)
+      .closest('a') as HTMLAnchorElement;
+    await userEvent.click(imageAnchor);
+    expect(trackEventSpy).toHaveBeenCalledWith('download_image');
+  });
+
+  it('tracks download_all_zip event when "Download all" is clicked', async () => {
+    render(<App />);
+    const fileInput = selectAndGetFileInput();
+    await uploadAndCheck(fileInput, [validFile1, validFile2]);
+    await checkConvertedFiles([validFile1, validFile2]);
+    const downloadAllLink = await screen.findByTitle(/download all images/i);
+    await userEvent.click(downloadAllLink);
+    expect(trackEventSpy).toHaveBeenCalledWith('download_all_zip', {
+      count: 2,
+    });
   });
 });

--- a/src/components/__tests__/UpdatePrompt.tsx
+++ b/src/components/__tests__/UpdatePrompt.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { useRegisterSW } from 'virtual:pwa-register/react';
 import UpdatePrompt from '../UpdatePrompt';
+import * as analytics from '../../helpers/analytics';
 
 vi.mock('virtual:pwa-register/react', () => ({
   useRegisterSW: vi.fn(),
@@ -14,8 +15,11 @@ const mockSetNeedRefresh = vi.fn();
 const mockUseRegisterSW = vi.mocked(useRegisterSW);
 
 describe('UpdatePrompt', () => {
+  let trackEventSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    trackEventSpy = vi.spyOn(analytics, 'trackEvent');
   });
 
   it('renders nothing when no update is available', () => {
@@ -51,6 +55,17 @@ describe('UpdatePrompt', () => {
     render(<UpdatePrompt />);
     await userEvent.click(screen.getByRole('button', { name: /update/i }));
     expect(mockUpdateServiceWorker).toHaveBeenCalledWith(true);
+  });
+
+  it('tracks pwa_update_accepted event when Update is clicked', async () => {
+    mockUseRegisterSW.mockReturnValue({
+      needRefresh: [true, mockSetNeedRefresh],
+      offlineReady: [false, vi.fn()],
+      updateServiceWorker: mockUpdateServiceWorker,
+    });
+    render(<UpdatePrompt />);
+    await userEvent.click(screen.getByRole('button', { name: /update/i }));
+    expect(trackEventSpy).toHaveBeenCalledWith('pwa_update_accepted');
   });
 
   it('calls setNeedRefresh(false) when Dismiss is clicked', async () => {

--- a/src/helpers/__tests__/analytics.test.ts
+++ b/src/helpers/__tests__/analytics.test.ts
@@ -1,0 +1,25 @@
+import { trackEvent } from '../analytics';
+
+describe('trackEvent', () => {
+  afterEach(() => {
+    delete window.gtag;
+  });
+
+  it('calls window.gtag with event name and params when gtag is defined', () => {
+    window.gtag = vi.fn();
+    trackEvent('test_event', { count: 3 });
+    expect(window.gtag).toHaveBeenCalledWith('event', 'test_event', {
+      count: 3,
+    });
+  });
+
+  it('calls window.gtag with only event name when no params given', () => {
+    window.gtag = vi.fn();
+    trackEvent('test_event');
+    expect(window.gtag).toHaveBeenCalledWith('event', 'test_event', undefined);
+  });
+
+  it('does not throw when window.gtag is not defined', () => {
+    expect(() => trackEvent('test_event', { count: 1 })).not.toThrow();
+  });
+});

--- a/src/helpers/analytics.ts
+++ b/src/helpers/analytics.ts
@@ -1,0 +1,8 @@
+export const trackEvent = (
+  eventName: string,
+  params?: Record<string, string | number>,
+) => {
+  if (typeof window.gtag === 'function') {
+    window.gtag('event', eventName, params);
+  }
+};

--- a/src/types/gtag.d.ts
+++ b/src/types/gtag.d.ts
@@ -1,0 +1,7 @@
+interface Window {
+  gtag?: (
+    command: string,
+    eventName: string,
+    params?: Record<string, string | number>,
+  ) => void;
+}


### PR DESCRIPTION
Add a trackEvent helper (with window.gtag guard for users who decline analytics cookies) and instrument key actions: file upload, image conversion (success and failure), individual download, ZIP download, clear all, and PWA update acceptance.