### PR TITLE
Bump serialize-javascript override to ^7.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10458,9 +10458,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "vanilla-cookieconsent": "^3.1.0"
   },
   "overrides": {
-    "serialize-javascript": "^7.0.3"
+    "serialize-javascript": "^7.0.5"
   },
   "lint-staged": {
     "*.{ts,tsx}": "eslint --fix"


### PR DESCRIPTION
## Summary

- Updates the `serialize-javascript` npm override from `^7.0.3` to `^7.0.5` to resolve a moderate severity vulnerability

## Security

Fixes [Dependabot alert #110](https://github.com/smtchahal/gta-snap-to-jpg/security/dependabot/110) — **CVE-2026-34043** / GHSA-qj8w-gfj5-8c6v: CPU exhaustion DoS in `serialize-javascript` < 7.0.5 via crafted array-like objects. The package is a transitive dev dependency pulled in by `vite-plugin-pwa` → `workbox-build` → `@rollup/plugin-terser`.

## Test plan

- [x] `npm ls serialize-javascript` confirms v7.0.5 is resolved
- [x] All tests pass with 100% coverage